### PR TITLE
Update dependencies, syntax and usage of Reactive extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "BrightFutures",
+        "repositoryURL": "https://github.com/Thomvis/BrightFutures.git",
+        "state": {
+          "branch": null,
+          "revision": "fa66fa183dce7196d431244d0215748cd14c5758",
+          "version": "8.2.0"
+        }
+      },
+      {
+        "package": "Erik",
+        "repositoryURL": "https://github.com/phimage/Erik.git",
+        "state": {
+          "branch": null,
+          "revision": "109a130e9cdb00789a43a7a625293eeb12d22989",
+          "version": "5.1.0"
+        }
+      },
+      {
+        "package": "FileKit",
+        "repositoryURL": "https://github.com/nvzqz/FileKit.git",
+        "state": {
+          "branch": null,
+          "revision": "826d9161b184509f80d85c28cd612d630646de98",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "package": "Kanna",
+        "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
+        "state": {
+          "branch": null,
+          "revision": "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
+          "version": "5.2.7"
+        }
+      },
+      {
+        "package": "OAuthSwift",
+        "repositoryURL": "https://github.com/OAuthSwift/OAuthSwift",
+        "state": {
+          "branch": "master",
+          "revision": "73f97878d988e33cc0d5482c18db6264c37ffbcd",
+          "version": null
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
+        "state": {
+          "branch": null,
+          "revision": "b4307ba0b6425c0ba4178e138799946c3da594f8",
+          "version": "6.5.0"
+        }
+      },
+      {
+        "package": "Swifter",
+        "repositoryURL": "https://github.com/httpswift/swifter.git",
+        "state": {
+          "branch": null,
+          "revision": "9483a5d459b45c3ffd059f7b55f9638e268632fd",
+          "version": "1.5.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -24,22 +24,22 @@
 import PackageDescription
 
 let package = Package(
-    name: "OAuthRxSwift",
-    products: [
-        .library(
-            name: "OAuthRxSwift",
-            targets: ["OAuthRxSwift"]
-        ),
-    ],
-    dependencies: [
-      .package(url: "https://github.com/OAuthSwift/OAuthSwift", .upToNextMajor(from: "2.1.2")),
-      .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.1.1")),
-    ],
-    targets: [
-        .target(
-            name: "OAuthRxSwift",
-            dependencies: ["OAuthSwift", "RxSwift"],
-            path: "Sources"
-        ),
-    ]
+  name: "OAuthRxSwift",
+  products: [
+    .library(
+      name: "OAuthRxSwift",
+      targets: ["OAuthRxSwift"]
+    ),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/OAuthSwift/OAuthSwift", .upToNextMajor(from: "2.1.2")),
+    .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.0.0")),
+  ],
+  targets: [
+    .target(
+      name: "OAuthRxSwift",
+      dependencies: ["OAuthSwift", "RxSwift"],
+      path: "Sources"
+    ),
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,22 +24,22 @@
 import PackageDescription
 
 let package = Package(
-  name: "OAuthRxSwift",
-  products: [
-    .library(
-      name: "OAuthRxSwift",
-      targets: ["OAuthRxSwift"]
-    ),
-  ],
-  dependencies: [
-    .package(url: "https://github.com/OAuthSwift/OAuthSwift", .upToNextMajor(from: "2.1.2")),
-    .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.0.0")),
-  ],
-  targets: [
-    .target(
-      name: "OAuthRxSwift",
-      dependencies: ["OAuthSwift", "RxSwift"],
-      path: "Sources"
-    ),
-  ]
+    name: "OAuthRxSwift",
+    products: [
+        .library(
+            name: "OAuthRxSwift",
+            targets: ["OAuthRxSwift"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/OAuthSwift/OAuthSwift", .branch("master")),
+        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.5.0")),
+    ],
+    targets: [
+        .target(
+            name: "OAuthRxSwift",
+            dependencies: ["OAuthSwift", "RxSwift"],
+            path: "Sources"
+        ),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:5.3
+//
 // Package.swift
 /*
  The MIT License (MIT)
@@ -23,8 +25,21 @@ import PackageDescription
 
 let package = Package(
     name: "OAuthRxSwift",
+    products: [
+        .library(
+            name: "OAuthRxSwift",
+            targets: ["OAuthRxSwift"]
+        ),
+    ],
     dependencies: [
-        .Package(url: "https://github.com/OAuthSwift/OAuthSwift.git", majorVersion: 1),
-        .Package(url: "https://github.com/ReactiveX/RxSwift.git", majorVersion: 3),
+      .package(url: "https://github.com/OAuthSwift/OAuthSwift", .upToNextMajor(from: "2.1.2")),
+      .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.1.1")),
+    ],
+    targets: [
+        .target(
+            name: "OAuthRxSwift",
+            dependencies: ["OAuthSwift", "RxSwift"],
+            path: "Sources"
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Utility methods to produce `Observable` from [RxSwift](https://github.com/Reacti
 This framework provide prefixed functions `rx_` on `OAuth1Swift` and `OAuth2Swift` class
 
 ```swift
-let observable = oauthSwift.rx_authorize(withCallbackURL: ..)
+let observable = oauthSwift.rx.authorize(withCallbackURL: ..)
 
 ```
 

--- a/Sources/OAuthRxSwift.swift
+++ b/Sources/OAuthRxSwift.swift
@@ -10,94 +10,42 @@ import Foundation
 import OAuthSwift
 import RxSwift
 
-extension OAuthSwift {
-    public typealias ObservableElement = (credential: OAuthSwiftCredential, response: URLResponse?, parameters: Parameters) // see OAuthSwift.TokenSuccessHandler TODO replace with OAuthSwift.TokenSuccess
+
+extension Reactive where Base == OAuth1Swift {
+  public func authorize(withCallbackURL url: URLConvertible, headers: OAuthSwift.Headers? = nil) -> Observable<OAuthSwift.TokenSuccess> {
+    Observable.create { (observer: AnyObserver<OAuthSwift.TokenSuccess>) in
+      let requestHandle = self.base.authorize(withCallbackURL: url, headers: headers) { result in
+        observer.on(result.asEvent)
+        observer.on(.completed)
+      }
+      return Disposables.create {
+        requestHandle?.cancel()
+      }
+    }
+  }
 }
 
-extension OAuth1Swift {
-
-    open func rx_authorize(withCallbackURL callbackURL: URL) -> Observable<ObservableElement> {
-        return Observable<ObservableElement>.create{ (observer: AnyObserver<ObservableElement>) -> Disposable in
-            let handle = self.authorize(
-                withCallbackURL: callbackURL,
-                success: { credential, response, parameters in
-                    observer.onNext((credential, response, parameters))
-                    observer.onCompleted()
-                },
-                failure: { error in
-                    observer.onError(error)
-                }
-            )
-            // else an error has been thrown
-            return Disposables.create {
-                handle?.cancel()
-            }
-            }.share()
+extension Reactive where Base == OAuth2Swift {
+  public func authorize(withCallbackURL callbackURL: URLConvertible?, scope: String, state: String, parameters: OAuth2Swift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> Observable<OAuthSwift.TokenSuccess> {
+    Observable.create { (observer: AnyObserver<OAuthSwift.TokenSuccess>) in
+      let requestHandle = self.base.authorize(withCallbackURL: callbackURL, scope: scope, state: state, parameters: parameters, headers: headers) { result in
+        observer.on(result.asEvent)
+        observer.on(.completed)
+      }
+      return Disposables.create {
+        requestHandle?.cancel()
+      }
     }
-    
-    @nonobjc open func rx_authorize(withCallbackURL callbackURL: String) -> Observable<ObservableElement> {
-        return Observable<ObservableElement>.create{ (observer: AnyObserver<ObservableElement>) -> Disposable in
-            let handle = self.authorize(
-                withCallbackURL: callbackURL,
-                success: { credential, response, parameters in
-                    observer.onNext((credential, response, parameters))
-                    observer.onCompleted()
-                },
-                failure: { error in
-                    observer.onError(error)
-                }
-            )
-            // else an error has been thrown
-            return Disposables.create {
-                handle?.cancel()
-            }
-            }.share()
-    }
-
+  }
 }
 
-extension OAuth2Swift {
-    
-    open func rx_authorize(withCallbackURL callbackURL: URL, scope: String, state: String, parameters: Parameters = [:], headers: Headers? = nil) -> Observable<ObservableElement> {
-        
-        return Observable<ObservableElement>.create{ (observer: AnyObserver<ObservableElement>) -> Disposable in
-            let handle = self.authorize(
-                withCallbackURL: callbackURL,
-                scope: scope, state: state, parameters: parameters, headers: headers,
-                success: { credential, response, parameters in
-                    observer.onNext((credential, response, parameters))
-                    observer.onCompleted()
-                },
-                failure: { error in
-                    observer.onError(error)
-                }
-            )
-            // else an error has been thrown
-            return Disposables.create {
-                handle?.cancel()
-            }
-            }.share()
+extension Result {
+  var asEvent: Event<Success> {
+    switch self {
+      case let .success(element):
+        return .next(element)
+      case let .failure(error):
+        return .error(error)
     }
-
-    @nonobjc open func rx_authorize(withCallbackURL callbackURL: String, scope: String, state: String, parameters: Parameters = [:], headers: Headers? = nil) -> Observable<ObservableElement> {
-        
-        return Observable<ObservableElement>.create{ (observer: AnyObserver<ObservableElement>) -> Disposable in
-            let handle = self.authorize(
-                withCallbackURL: callbackURL,
-                scope: scope, state: state, parameters: parameters, headers: headers,
-                success: { credential, response, parameters in
-                    observer.onNext((credential, response, parameters))
-                    observer.onCompleted()
-                },
-                failure: { error in
-                    observer.onError(error)
-                }
-            )
-            // else an error has been thrown
-            return Disposables.create {
-                handle?.cancel()
-            }
-            }.share()
-    }
-
+  }
 }


### PR DESCRIPTION
Usage: call `oauthSwift.rx.authorize` instead of calling `oauthSwift.authorize`. 
The proposed syntax does not erase the syntax of `oauthSwift.authorize`.